### PR TITLE
Upgrading vulnerable request

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "asyncawait": "^1.0.3",
     "bluebird": "^3.3.4",
-    "request": "^2.69.0",
+    "request": "^2.83.0",
     "yargs": "^4.2.0"
   }
 }


### PR DESCRIPTION
Would it be possible to upgrade `request` because of the following vulnerability?

| Issue | https://nodesecurity.io/advisories/566 |
| :--- | :--- |
| Dependency Graph| sentry-sourcemaps-alt@0.2.5 > request@2.81.0 > hawk@3.1.3 > hoek@2.16.3  |
